### PR TITLE
feat: fix coin gecko rate limiting and rework setting network type

### DIFF
--- a/src/chains/avalanche/AvalancheChainOperations.ts
+++ b/src/chains/avalanche/AvalancheChainOperations.ts
@@ -27,7 +27,7 @@ export class AvalancheChainOperations implements IChainOperations {
       this.chainConfig.type
     ).privateKey!;
 
-    this.coinGeckoApiService = new CoinGeckoApiService();
+    this.coinGeckoApiService = new CoinGeckoApiService(this.configService);
     this.evmRpcOps = new EvmRpcOperations(
       this.chainConfig.rpcUrls.default.http[0]!,
       privateKey as `0x${string}`

--- a/src/chains/hedera/HederaChainOperations.ts
+++ b/src/chains/hedera/HederaChainOperations.ts
@@ -30,7 +30,7 @@ export class HederaChainOperations implements IChainOperations {
     ).privateKey!;
     const hexPrivateKey = parseDerKeyToHex(privateKey);
 
-    this.coinGeckoApiService = new CoinGeckoApiService();
+    this.coinGeckoApiService = new CoinGeckoApiService(configService);
     this.evmRpcOps = new EvmRpcOperations(
       this.chainConfig.rpcUrls.default.http[0]!,
       hexPrivateKey

--- a/src/chains/hedera/HederaNativeOperations.ts
+++ b/src/chains/hedera/HederaNativeOperations.ts
@@ -40,9 +40,7 @@ export class HederaNativeOperations implements INativeHederaSdkOperations {
 
   constructor(configService: ConfigService) {
     this.configService = configService;
-    const networkType = this.configService.getWalletCredentials(
-      SupportedChain.HEDERA
-    ).networkType!;
+    const networkType = this.configService.getNetworkType();
     const privateKey = this.configService.getWalletCredentials(
       SupportedChain.HEDERA
     ).privateKey!;
@@ -209,8 +207,7 @@ export class HederaNativeOperations implements INativeHederaSdkOperations {
       throw new Error('Account creation failed');
 
     return this.createClient(
-      this.configService.getWalletCredentials(SupportedChain.HEDERA)
-        .networkType!,
+      this.configService.getNetworkType(),
       receipt.accountId?.toString()!,
       accountPrivateKey.toStringDer()
     );

--- a/src/chains/optimism/OptimismChainOperations.ts
+++ b/src/chains/optimism/OptimismChainOperations.ts
@@ -27,7 +27,7 @@ export class OptimismChainOperations implements IChainOperations {
       this.chainConfig.type
     ).privateKey!;
 
-    this.coinGeckoApiService = new CoinGeckoApiService();
+    this.coinGeckoApiService = new CoinGeckoApiService(this.configService);
     this.evmRpcOps = new EvmRpcOperations(
       this.chainConfig.rpcUrls.default.http[0]!,
       privateKey as `0x${string}`

--- a/src/chains/solana/SolanaChainOperations.ts
+++ b/src/chains/solana/SolanaChainOperations.ts
@@ -20,7 +20,7 @@ export class SolanaChainOperations implements IChainOperations {
 
   constructor(private configService: ConfigService) {
     this.chainConfig = this.configService.getChainConfig(SupportedChain.SOLANA);
-    this.coinGeckoApiService = new CoinGeckoApiService();
+    this.coinGeckoApiService = new CoinGeckoApiService(this.configService);
     this.nativeSdkOps = new SolanaNativeOperations(configService);
     this.solPriceInUsd = undefined;
   }

--- a/src/chains/stellar/StellarChainOperations.ts
+++ b/src/chains/stellar/StellarChainOperations.ts
@@ -22,7 +22,7 @@ export class StellarChainOperations implements IChainOperations {
     this.chainConfig = this.configService.getChainConfig(
       SupportedChain.STELLAR
     );
-    this.coinGeckoApiService = new CoinGeckoApiService();
+    this.coinGeckoApiService = new CoinGeckoApiService(this.configService);
     this.nativeSdkOps = new StellarNativeOperations(configService);
     this.stellarPriceInUsd = undefined;
   }

--- a/src/chains/stellar/StellarNativeOperations.ts
+++ b/src/chains/stellar/StellarNativeOperations.ts
@@ -12,6 +12,7 @@ import { ConfigService } from '../../services/ConfigService/ConfigService';
 import {
   AccountData,
   ChainConfig,
+  NetworkType,
   SupportedChain,
   TransactionResult,
   WalletCredentials,
@@ -27,6 +28,7 @@ function getStellarNetworkPassphrase(network: string): string {
 export class StellarNativeOperations implements IStellarNativeOperations {
   private configService: ConfigService;
   private chainConfig: ChainConfig;
+  private networkType: NetworkType;
   private readonly server: Horizon.Server;
   private readonly issuerKeypair: Keypair;
   private readonly networkPassphrase: string;
@@ -36,14 +38,13 @@ export class StellarNativeOperations implements IStellarNativeOperations {
   constructor(configService: ConfigService) {
     this.configService = configService;
     this.chainConfig = configService.getChainConfig(SupportedChain.STELLAR);
+    this.networkType = configService.getNetworkType();
     this.server = new Horizon.Server(this.chainConfig.rpcUrls.default.http[0]!);
     const credentials: WalletCredentials =
       this.configService.getWalletCredentials(SupportedChain.STELLAR);
     this.issuerKeypair = Keypair.fromSecret(credentials.privateKey!);
 
-    this.networkPassphrase = getStellarNetworkPassphrase(
-      this.chainConfig.network
-    );
+    this.networkPassphrase = getStellarNetworkPassphrase(this.networkType);
   }
 
   async isHealthy(): Promise<boolean> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ async function main() {
     console.log('--- CLI FLAGS ---');
     console.log(cliConfig);
 
-    const tool = new CostComparisonTool();
+    const tool = new CostComparisonTool(cliConfig.network);
     await tool.run(cliConfig.chains, cliConfig.operations);
   } catch (error) {
     console.error(

--- a/src/services/ApiService/CoinGeckoApiService.ts
+++ b/src/services/ApiService/CoinGeckoApiService.ts
@@ -1,26 +1,37 @@
 import { z } from 'zod';
+import { ConfigService } from '../ConfigService/ConfigService';
 
 const coinGeckoSchemas = {
-  'hedera-hashgraph': z.object({ 'hedera-hashgraph': z.object({ usd: z.number() }) }),
-  'ethereum': z.object({
-    'ethereum': z.object({ usd: z.number() }),
+  'hedera-hashgraph': z.object({
+    'hedera-hashgraph': z.object({ usd: z.number() }),
   }),
-  'solana': z.object({ solana: z.object({ usd: z.number() }) }),
-  'stellar': z.object({ stellar: z.object({ usd: z.number() }) }),
+  ethereum: z.object({ ethereum: z.object({ usd: z.number() }) }),
+  solana: z.object({ solana: z.object({ usd: z.number() }) }),
+  stellar: z.object({ stellar: z.object({ usd: z.number() }) }),
   'avalanche-2': z.object({ 'avalanche-2': z.object({ usd: z.number() }) }),
 };
 
 export class CoinGeckoApiService {
+  constructor(private configService: ConfigService) {}
+
   async getPriceInUsd<T>(tokenId: string, schema: z.ZodType<T>): Promise<T> {
-    const url = `https://api.coingecko.com/api/v3/simple/price?ids=${tokenId}&vs_currencies=usd`;
+    const apiKey = this.configService.getCoinGeckoApiKey();
+    const baseUrl = 'https://api.coingecko.com/api/v3';
+    const apiKeyParam = apiKey ? `&x_cg_demo_api_key=${apiKey}` : '';
+    const url = `${baseUrl}/simple/price?ids=${tokenId}&vs_currencies=usd${apiKeyParam}`;
 
     const response = await fetch(url, {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
 
     if (!response.ok) {
-      throw new Error(`Failed to fetch ${tokenId} price`);
+      throw new Error(
+        `Failed to fetch ${tokenId} price (status ${response.status}). The response body: ${await response.text()}. 
+        NOTE: This issue might be caused by the CoinGecko API rate limiting. Please consider adding free COINGECKO_API_KEY.`
+      );
     }
 
     const json = await response.json();

--- a/src/services/ApiService/HederaMirrorNodeService.ts
+++ b/src/services/ApiService/HederaMirrorNodeService.ts
@@ -1,11 +1,10 @@
-import { ConfigService } from "../ConfigService/ConfigService";
-import { SupportedChain } from "../../types";
-import { AccountId } from "@hashgraph/sdk";
-import axios, { AxiosInstance } from "axios";
+import { ConfigService } from '../ConfigService/ConfigService';
+import { AccountId } from '@hashgraph/sdk';
+import axios, { AxiosInstance } from 'axios';
 
 export enum HederaKeyType {
-  ECDSA_SECP256K1 = "ECDSA_SECP256K1",
-  ED25519 = "ED25519",
+  ECDSA_SECP256K1 = 'ECDSA_SECP256K1',
+  ED25519 = 'ED25519',
 }
 
 export class HederaMirrorNodeService {
@@ -14,7 +13,7 @@ export class HederaMirrorNodeService {
   private axiosInstance: AxiosInstance;
 
   constructor(configService: ConfigService) {
-    this.networkType = configService.getWalletCredentials(SupportedChain.HEDERA).networkType!;
+    this.networkType = configService.getNetworkType();
     switch (this.networkType) {
       case 'mainnet':
         this.baseUrl = 'https://mainnet.mirrornode.hedera.com/api/v1';
@@ -32,7 +31,7 @@ export class HederaMirrorNodeService {
     this.axiosInstance = axios.create({
       baseURL: this.baseUrl,
       headers: {
-        'accept': 'application/json',
+        accept: 'application/json',
       },
     });
   }
@@ -43,16 +42,20 @@ export class HederaMirrorNodeService {
       const response = await this.axiosInstance.get(`/accounts/${id}`);
       const keyType = response.data?.key?._type;
 
-      if (keyType === HederaKeyType.ECDSA_SECP256K1 || keyType === HederaKeyType.ED25519) {
+      if (
+        keyType === HederaKeyType.ECDSA_SECP256K1 ||
+        keyType === HederaKeyType.ED25519
+      ) {
         return keyType;
       } else {
         throw new Error(`Unknown key type: ${keyType}`);
       }
     } catch (error) {
-      throw new Error(`Failed to fetch account info: ${(error as Error).message}`);
+      throw new Error(
+        `Failed to fetch account info: ${(error as Error).message}`
+      );
     }
   }
-
 
   async getEvmAddress(accountId: AccountId): Promise<string> {
     const id = accountId.toString();
@@ -66,7 +69,9 @@ export class HederaMirrorNodeService {
         throw new Error(`EVM address not found for account ${id}`);
       }
     } catch (error) {
-      throw new Error(`Failed to fetch EVM address: ${(error as Error).message}`);
+      throw new Error(
+        `Failed to fetch EVM address: ${(error as Error).message}`
+      );
     }
   }
 }

--- a/src/services/ConfigService/ConfigService.ts
+++ b/src/services/ConfigService/ConfigService.ts
@@ -12,11 +12,13 @@ dotenv.config();
 export class ConfigService {
   private config: Map<string, any> = new Map();
   private chainsConfigs: ChainConfig[];
-  private networkType: NetworkType | undefined;
+  private networkType: NetworkType;
+  private coinGeckoApiKey: string | undefined;
 
-  constructor() {
+  constructor(networkType: NetworkType) {
     this.loadFromEnv();
     this.chainsConfigs = initSupportedChains();
+    this.networkType = networkType;
   }
 
   public getChainConfig(chainType: SupportedChain): ChainConfig {
@@ -26,16 +28,7 @@ export class ConfigService {
   }
 
   private loadFromEnv(): void {
-    const networkType = process.env.NETWORK_TYPE?.toLowerCase();
-    if (
-      !networkType ||
-      !Object.values(NetworkType).includes(networkType as NetworkType)
-    ) {
-      throw new Error(
-        `Invalid or missing NETWORK_TYPE in environment: received "${networkType}"`
-      );
-    }
-    this.networkType = networkType as NetworkType;
+    this.coinGeckoApiKey = process.env.COINGECKO_API_KEY;
 
     Object.keys(process.env).forEach((key) => {
       if (key.startsWith('WALLET_')) {
@@ -49,7 +42,14 @@ export class ConfigService {
     return {
       privateKey: this.config.get(`WALLET_${upperChain}_PRIVATE_KEY`),
       address: this.config.get(`WALLET_${upperChain}_ADDRESS`),
-      networkType: this.networkType,
     };
+  }
+
+  public getNetworkType(): NetworkType {
+    return this.networkType;
+  }
+
+  public getCoinGeckoApiKey(): string | undefined {
+    return this.coinGeckoApiKey;
   }
 }

--- a/src/services/CostComparisonTool.ts
+++ b/src/services/CostComparisonTool.ts
@@ -4,6 +4,7 @@ import {
   SupportedChain,
   SupportedOperation,
   FullTransactionResult,
+  NetworkType,
 } from '../types';
 import { ChainOperationsFactory } from '../chains/factories/OperationsFactory';
 import { IChainOperations } from '../chains/abstract/IChainOperations';
@@ -14,8 +15,8 @@ export class CostComparisonTool {
   private chainOperationsFactory: ChainOperationsFactory;
   private csvService: CsvService;
 
-  constructor() {
-    this.configService = new ConfigService();
+  constructor(network: NetworkType) {
+    this.configService = new ConfigService(network);
     this.chainOperationsFactory = new ChainOperationsFactory(
       this.configService
     );

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,6 +1,6 @@
 import minimist from 'minimist';
 import { z } from 'zod';
-import { SupportedChain, SupportedOperation } from '../types';
+import { NetworkType, SupportedChain, SupportedOperation } from '../types';
 
 const rawArgs = minimist(process.argv.slice(2));
 
@@ -8,14 +8,16 @@ const supportedChains = Object.values(SupportedChain);
 const supportedOperations = Object.values(SupportedOperation);
 
 const cliSchema = z.object({
-  network: z.enum(['testnet', 'mainnet']).default('testnet'),
+  network: z.nativeEnum(NetworkType).default(NetworkType.TESTNET),
 
   chains: z
     .string()
     .transform((val) => val.split(','))
     .refine(
       (chains): chains is SupportedChain[] =>
-        chains.every((chain) => supportedChains.includes(chain as SupportedChain)),
+        chains.every((chain) =>
+          supportedChains.includes(chain as SupportedChain)
+        ),
       {
         message: `Invalid chain provided. Allowed chains: ${supportedChains.join(', ')}`,
       }
@@ -26,7 +28,9 @@ const cliSchema = z.object({
     .transform((val) => val.split(','))
     .refine(
       (ops): ops is SupportedOperation[] =>
-        ops.every((op) => supportedOperations.includes(op as SupportedOperation)),
+        ops.every((op) =>
+          supportedOperations.includes(op as SupportedOperation)
+        ),
       {
         message: `Invalid method provided. Allowed operations: ${supportedOperations.join(', ')}`,
       }


### PR DESCRIPTION
- user can optionally set the COINGECKO_API_KEY env variable to increase the rate limiting to 30 requests per minute\
- now the `networkType` is passed through the CLI app param `--network=testnet`, not with use of the `NETWORK_TYPE` env variable